### PR TITLE
Allow to execute as System User instead of user 1 (admin)

### DIFF
--- a/src/DRI/SugarCRM/Console/Application.php
+++ b/src/DRI/SugarCRM/Console/Application.php
@@ -61,12 +61,14 @@ class Application
     /**
      * @param int $current_user_id
      */
-    public function loadCurrentUser($current_user_id = 1)
+    public function loadCurrentUser($current_user_id = null)
     {
         global $current_user;
 
-        if (empty($current_user->id)) {
+        if (empty($current_user->id) && !empty($current_user_id)) {
             $current_user->retrieve($current_user_id);
+        } elseif (empty($current_user->id)) {
+            $current_user->getSystemUser();
         }
 
         $this->current_user = $current_user;


### PR DESCRIPTION
For example, if your Sugar Administrator is not user with Id 1, and the user with Id 1 is disabled, the console script will fail.
